### PR TITLE
Add testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: python
 cache: pip
 install:
   - pip install black
-  - pip install -e '.'
-script:
-  - black --check --verbose .
+  - pip install -r requirements.txt
+  - pip install -e '.[build]'
+jobs:
+  include:
+    - stage: "Code Formatting"
+      script: black --check --verbose .
+    - stage: "Tests"
+      name: "Unit Tests"
+      script: pytest

--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,5 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     packages=find_packages(),
+    extras_require={"build": ["pytest"]},
 )

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -7,6 +7,16 @@ import xarray as xr
 import filtering
 
 
+def velocity_series(nt, U0, f):
+    """Construct a 1D velocity timeseries."""
+
+    t = np.arange(nt) + 1
+    t0 = nt // 2 + 1  # middle time index
+    u = U0 + (U0 / 2) * np.sin(2 * np.pi * f * (t - t0))
+
+    return t, u
+
+
 def test_sanity():
     """Sanity check of filtering.
 
@@ -15,13 +25,73 @@ def test_sanity():
     """
 
     # construct sample times (hrs) and velocity field (m/hr)
-    t = np.arange(25) + 1  # 12 hours on either side of the centre point
-    U0 = 100.0 / 24
-    u = U0 + (U0 / 2) * np.sin(2 * np.pi / 6 * (t - 13))
-
-    assert u[12] == pytest.approx(U0)
+    U0 = 100 / 24
+    w = 1 / 6  # tidal frequency
+    nt = 37
+    _, u = velocity_series(nt, U0, w)
+    assert u[nt // 2] == pytest.approx(U0)
 
     # construct filter
-    f = signal.butter(4, 1 / 3, "highpass")
+    f = signal.butter(4, w / 2, "highpass")
     fu = signal.filtfilt(*f, u)
-    assert fu[12] == pytest.approx(0.0, abs=1e-4)
+    assert fu[nt // 2] == pytest.approx(0.0, abs=1e-2)
+
+
+def test_sanity_filtering_from_dataset(tmp_path):
+    """Sanity check of filtering using the library.
+
+    As with the :func:`~test_sanity` test, this sets up a mean
+    velocity field (in 2D) with an oscillating component. Because the
+    velocity field is uniform in time, the Lagrangian timeseries
+    should be the same as the 1D timeseries.
+    """
+
+    U0 = 100 / 24
+    w = 1 / 6
+    nt = 37
+    t, u = velocity_series(nt, U0, w)
+
+    # convert hours to seconds
+    u /= 3600
+    t *= 3600
+
+    x = np.array([0, 500, 1000])
+    y = np.array([0, 500, 1000])
+
+    # broadcast velocity to right shape
+    u_full = np.empty((nt, y.size, x.size))
+    u_full[:] = u[:, None, None]
+
+    # create dataset
+    d = xr.Dataset(
+        {
+            "u": (["time", "y", "x"], u_full),
+            "v": (["time", "y", "x"], np.zeros_like(u_full)),
+        },
+        coords={"x": x, "y": y, "time": t},
+    )
+
+    # dump to file
+    p = tmp_path / "data.nc"
+    d.to_netcdf(p)
+
+    f = filtering.LagrangeFilter(
+        "sanity_test",
+        {"U": str(p), "V": str(p)},
+        {"U": "u", "V": "v"},
+        {"lon": "x", "lat": "y", "time": "time"},
+        sample_variables=["U"],
+        mesh="flat",
+        window_size=17 * 3600,
+        highpass_frequency=(w / 2) / 3600,
+        advection_dt=30 * 60,
+    )
+
+    # filter from the middle of the series
+    filtered = f.filter_step(t[nt // 2])["var_U"]
+    # we expect a lot of parcels to hit the edge and die
+    # but some should stay alive
+    filtered = filtered[~np.isnan(filtered)]
+    assert filtered.size > 0
+    value = filtered.item(0)
+    assert value == pytest.approx(0.0, abs=1e-3)

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -1,0 +1,27 @@
+import pytest
+
+import numpy as np
+from scipy import signal
+import xarray as xr
+
+import filtering
+
+
+def test_sanity():
+    """Sanity check of filtering.
+
+    Set up a mean velocity field with an oscillating component,
+    then filter out the mean.
+    """
+
+    # construct sample times (hrs) and velocity field (m/hr)
+    t = np.arange(25) + 1  # 12 hours on either side of the centre point
+    U0 = 100.0 / 24
+    u = U0 + (U0 / 2) * np.sin(2 * np.pi / 6 * (t - 13))
+
+    assert u[12] == pytest.approx(U0)
+
+    # construct filter
+    f = signal.butter(4, 1 / 3, "highpass")
+    fu = signal.filtfilt(*f, u)
+    assert fu[12] == pytest.approx(0.0, abs=1e-4)


### PR DESCRIPTION
This allows for unit and integration tests through _pytest,_ for demonstration of correct behaviour as well as checking for regressions. The tests are run through travis, so they should occur both on regular pushes, and on all pull requests. At the moment, there are only a couple of very simple sanity checks, more as a test of the framework itself than the code. Further additions to the codebase should add tests where necessary, and not break existing tests.

This gives us some progress on #3, but I'm not willing to call it closed at this point.