### PR TITLE
Cut off ends of advected data before filtering

### DIFF
--- a/filtering/filtering.py
+++ b/filtering/filtering.py
@@ -423,7 +423,7 @@ class LagrangeFilter(object):
             # for var_array_forward, skip the initial output for both the sample-only and
             # sample-advection kernels, which have meaningless data
             var_array = da.concatenate(
-                (da.flip(var_array_backward[1:, :], axis=0), var_array_forward)
+                (da.flip(var_array_backward[1:-1, :], axis=0), var_array_forward[:-1])
             )
 
             def filter_select(x):


### PR DESCRIPTION
Not sure how I missed this one, but `ParticleSet.execute` writes data at the end of advection. Because we always do advection on a multiple of output timesteps, this means that the last timestep is duplicated in the output data. I had accounted for this in the test cases, but not in `filter_step` itself, so the filtering was doubling up the data on the ends of the series.