### PR TITLE
Fix xarray test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     packages=find_packages(),
-    extras_require={"build": ["pytest"]},
+    extras_require={"build": ["pytest", "xarray"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     packages=find_packages(),
-    extras_require={"build": ["pytest", "xarray"]},
+    extras_require={"build": ["pytest", "xarray", "cloudpickle"]},
 )


### PR DESCRIPTION
Two issues here: first up, there was no explicit dependency on xarray for tests, even though it is one. Secondly, xarray 0.14.0 has a bug that can be worked around by installing cloudpickle. Since this only affects the test environment, I'm happy to install this as a temporary measure, rather than specifying dependency versions.