### PR TITLE
Concatenate particle data in advection, not filtering step

### DIFF
--- a/docs/exploring.rst
+++ b/docs/exploring.rst
@@ -1,0 +1,25 @@
+===========================
+ Exploring Lagrangian Data
+===========================
+
+While the main aim of the `lagrangian-filtering` library is the
+filtering of the Lagrangian-transformed data, it can be useful to work
+with the transformed data in an exploratory capacity. Suppose we have
+a new dataset on which we'd like to perform the filtering. Two choices
+need to be made straight away: what is the high-pass cutoff frequency,
+and what is a sensible advection timestep? Certainly prior experience
+and an idea of the source model parameters like Coriolis parameter and
+timestep are useful, however directly interrogating the data may lead
+to better results.
+
+Under the hood (see also the :doc:`algorithm <algorithm>` description), the
+Lagrangian transformation can be performed in isolation with
+:meth:`~filtering.filtering.LagrangeFilter.advection_step`. For example,
+to compute the mean Lagrangian velocity, which could then be used to
+compute a spectrum for determining an ideal cutoff frequency:
+
+.. code-block:: python
+
+   f = LagrangeFilter(...)
+   data = f.advection_step(time)
+   mean_u = np.mean(data["var_U"][1], axis=1)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ GitHub_.
 
    installation
    algorithm
+   exploring
    contributing
    api
 

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -96,20 +96,9 @@ def test_sanity_advection(tmp_path):
         advection_dt=60,
     )
 
-    transformed = f.advection_step(t[nt // 2])
-    t_trans = np.concatenate(
-        (
-            transformed.data("backward").attrs["time"][1:-1][::-1],
-            transformed.data("forward").attrs["time"][:-1],
-        )
-    )
-
-    u_trans = np.concatenate(
-        (
-            transformed.data("backward")["var_U"][1:-1, 4][::-1],
-            transformed.data("forward")["var_U"][:-1, 4],
-        )
-    )
+    transformed = f.advection_step(t[nt // 2], output_time=True)
+    t_trans = transformed["time"]
+    u_trans = transformed["var_U"][1][:, 4].compute()
 
     assert np.allclose(u, u_trans, rtol=1e-1)
     assert np.array_equal(t, t_trans)
@@ -143,12 +132,7 @@ def test_zonally_periodic_advection(tmp_path):
     f.make_zonally_periodic(width=3)
 
     transformed = f.advection_step(t[nt // 2])
-    u_trans = np.concatenate(
-        (
-            transformed.data("backward")["var_U"][1:-1, :][::-1],
-            transformed.data("forward")["var_U"][:-1, :],
-        )
-    )
+    u_trans = transformed["var_U"][1].compute()
 
     assert not np.any(np.isnan(u_trans))
 
@@ -181,12 +165,7 @@ def test_meridionally_periodic_advection(tmp_path):
     f.make_meridionally_periodic(width=3)
 
     transformed = f.advection_step(t[nt // 2])
-    v_trans = np.concatenate(
-        (
-            transformed.data("backward")["var_V"][1:-1, :][::-1],
-            transformed.data("forward")["var_V"][:-1, :],
-        )
-    )
+    v_trans = transformed["var_V"][1].compute()
 
     assert not np.any(np.isnan(v_trans))
 
@@ -219,12 +198,7 @@ def test_doubly_periodic_advection(tmp_path):
     f.make_meridionally_periodic(width=3)
 
     transformed = f.advection_step(t[nt // 2])
-    v_trans = np.concatenate(
-        (
-            transformed.data("backward")["var_V"][1:-1, :][::-1],
-            transformed.data("forward")["var_V"][:-1, :],
-        )
-    )
+    v_trans = transformed["var_V"][1].compute()
 
     assert not np.any(np.isnan(v_trans))
 


### PR DESCRIPTION
This way we can return the particle data straight out of the advection step and have it be usable for intermediate processing or analysis.

Closes #19.