### PR TITLE
Allow specification of absolute filtering times

### DIFF
--- a/filtering/filtering.py
+++ b/filtering/filtering.py
@@ -536,17 +536,29 @@ class LagrangeFilter(object):
         this latter case, only timesteps that have the full window
         size on either side are selected.
 
+        Note:
+            If `absolute` is True, the times must be the same datatype
+            as those the input data. For dates with a calendar, this
+            is likely :obj:`np.datetime64` or :obj:`cftime.datetime`.
+            For abstract times, this may simply be a number.
+
         Args:
             times (:obj:`[float]`, optional): A list of timesteps at
                 which to run the filtering. If this is omitted, all
                 timesteps that are fully covered by the filtering
                 window are selected.
 
+            absolute (:obj:`bool`, optional): If `times` is provided,
+                this argument determines whether to interpret them
+                as relative to the first timestep in the input dataset
+                (False, default), or as absolute, following the actual
+                time dimension in the dataset (True).
+
         """
 
         self(*args, **kwargs)
 
-    def __call__(self, times=None):
+    def __call__(self, times=None, absolute=False):
         """Run the filtering process on this experiment."""
 
         # run over the full range of valid time indices unless specified otherwise
@@ -562,6 +574,9 @@ class LagrangeFilter(object):
         window_left = times - tgrid[0] >= self.window_size
         window_right = times <= tgrid[-1] - self.window_size
         times = times[window_left & window_right]
+
+        if absolute:
+            times = self.fieldset.gridset.grids[0].time_origin.reltime(times)
 
         da_out = {v: [] for v in self.sample_variables}
 

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -289,3 +289,27 @@ def test_sanity_filtering_from_dataset(tmp_path):
     assert filtered.size > 0
     value = filtered.item(0)
     assert value == pytest.approx(0.0, abs=1e-3)
+
+
+def test_absolute_times(tmp_path):
+    """Test decoding of absolute times"""
+
+    nt = 37
+    w = 1 / 6
+    d, t, _ = velocity_dataset(nt, w)
+
+    t = t.copy()
+
+    # offset absolute and relative times
+    d["time"] += 1800
+
+    f = filtering.LagrangeFilter(
+        "absolute_times",
+        d,
+        {"U": "u", "V": "v"},
+        {"lon": "x", "lat": "y", "time": "time"},
+        sample_variables=[],
+        window_size=0,
+    )
+
+    assert np.all(f._window_times(d["time"], True) == t)


### PR DESCRIPTION
We can use parcels' `time_origin` object to convert absolute times to relative times. This is a bit awkward with datatypes, as it relies on native subtraction between whatever parcels decides is the origin time, and the times passed by the user. If the times are just loaded from xarray or something, they *should* end up with the right type.

Closes #35 