### PR TITLE
Support reducing seeding to a subdomain

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+import os
+
+
+@pytest.fixture
+def tmp_chdir(tmp_path):
+    # change to tmp_path, saving current directory
+    original_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    yield True
+
+    # restore original directory
+    os.chdir(original_dir)


### PR DESCRIPTION
Latitude/longitude ranges can be specified for particle seeding, and thus the points at which to perform filtering, which still having the full domain of input data available for advection.

Closes #8