### PR TITLE
Filter data down to a minimum window size

### DIFF
--- a/filtering/filtering.py
+++ b/filtering/filtering.py
@@ -672,10 +672,9 @@ class LagrangeFilter(object):
             filtered = da.apply_gufunc(
                 filter_select,
                 "(i)->()",
-                var_array,
+                var_array.rechunk((-1, "auto")),
                 axis=0,
                 output_dtypes=var_array.dtype,
-                allow_rechunk=True,
             )
 
             da_out[v] = filtered.compute()


### PR DESCRIPTION
The requirement that all advected data fits within the chosen filtering window is pretty strict, and means we end up throwing away a lot of data. However, we can still salvage points if only a few timesteps are missing (such as advecting out of the domain or into land at some point).

Closes #46.

## TODOs
- [x] Make the minimum window size configurable (currently hardcoded to half the actual window width)