### PR TITLE
Migrate to the upstream parcels distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 cache: pip
 install:
   - pip install -e '.[build]'
+  - pip install -r requirements.txt
 jobs:
   include:
     - stage: "Code Formatting"
@@ -10,7 +11,6 @@ jobs:
     - stage: "Tests"
       name: "Unit Tests"
       script: pytest
-      env: OMP_NUM_THREADS=1
     - stage: "Documentation"
       install: pip install sphinx
       before_script: cd docs

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Python environment.
 2. Change to the directory `cd lagrangian-filtering`
 3. (Optional) Create the virtualenv `virtualenv env` and activate it `source env/bin/activate`
 4. Install the development version of the package `pip install -e .`
+5. Install the dependencies required for parcels `pip install -r requirements.txt`
 
 #### Upgrading
 With the package installed in development mode, updating is as easy as

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ If you use Conda_ to manage Python packages, you may run
 
 .. code-block:: console
 
-   $ conda install -c angus-g -c conda-forge lagrangian-filtering
+   $ conda install -c conda-forge -c angus-g lagrangian-filtering
 
 to install this package and all its required dependencies. The ``-c
 angus-g`` flag must come before the ``-c conda-forge`` flag to ensure
@@ -25,7 +25,7 @@ in its own Conda environment:
 
 .. code-block:: console
 
-   $ conda create -n filtering -c angus-g -c conda-forge lagrangian-filtering
+   $ conda create -n filtering -c conda-forge -c angus-g lagrangian-filtering
 
 The created environment can be activated by running
 
@@ -45,8 +45,7 @@ Using Pip
 ---------
 
 On the other hand, you may not use Conda, or you wish to develop
-either `lagrangian-filtering` or its `modified OceanParcels
-dependency`_. In these cases, it is easier to install a modifiable
+for `lagrangian-filtering`. In these cases, it is easier to install a modifiable
 version of the package in a virtual environment.
 
 .. code-block:: console
@@ -56,6 +55,7 @@ version of the package in a virtual environment.
    $ virtualenv env
    $ source env/bin/activate
    $ pip install -e .
+   $ pip install -r requirements.txt
 
 This will install `lagrangian-filtering` as a
 development package, where changes to the files in the git repository
@@ -73,8 +73,6 @@ In the directory into which you cloned the repository. If the
    $ pip install --upgrade --upgrade-strategy eager .
 
 will pull changes to its corresponding git repository.
-
-.. _modified OceanParcels dependency: https://github.com/angus-g/parcels
 
 Working with Jupyter Notebooks
 ------------------------------

--- a/filtering/file.py
+++ b/filtering/file.py
@@ -140,20 +140,18 @@ class LagrangeParticleFile(object):
         """
 
         # don't write out deleted particles
-        if deleted_only:
+        if deleted_only is not False:
             return
 
         self._group.attrs["time"] = np.append(self._group.attrs["time"], time)
 
-        # find particles which have been deleted
-        missing = particleset.particle_data["state"] == ErrorCode.Delete
+        # indices of particles still alive
+        idx = particleset.particle_data["id"]
 
         for v, d in self._var_datasets.items():
-            # set data for deleted particles to nan, so the filtered output
-            # gets a nan to mark as invalid/missing
-            particleset.particle_data[v][missing] = np.nan
-
             # first, resize all datasets to add another entry in the time dimension
             # then we can just pull the array for this variable out of the particleset
             d.resize(d.shape[0] + 1, axis=0)
-            d[-1, :] = particleset.particle_data[v]
+            # data defaults to nans, and we only fill in the living particles
+            d[-1, :] = np.nan
+            d[-1, idx] = particleset.particle_data[v]

--- a/meta.yaml
+++ b/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - h5py
     - numpy >=1.17.0
     - scipy >=1.2.0
-    - parcels
+    - parcels >=2.1.5
 
 about:
   home: https://github.com/angus-g/lagrangian-filtering

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+psutil
+progressbar2
+cgen
+pymbolic

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     packages=find_packages(),
-    extras_require={"build": ["pytest", "xarray", "cloudpickle"]},
+    extras_require={"build": ["pytest",]},
     install_requires=[
         "dask[array]",
         "h5py",
@@ -16,6 +16,6 @@ setup(
         "xarray",
         "netCDF4",
         "cftime",
-        "parcels @ git+https://github.com/angus-g/parcels@lagrangian-filtering",
+        "parcels @ git+https://github.com/OceanParcels/parcels",
     ],
 )


### PR DESCRIPTION
Now that upstream parcels uses SoA (structure of arrays) and I have different solution to handling out-of-bounds particles, it would be a good time to use the upstream distribution so we can stay at feature parity.

Currently marked WIP because the SoA version of parcels doesn't have a release yet, so we can't robustly refer to it in `requirements.txt` or `meta.yaml` (for pip and Conda installs, respectively).

Also, because upstream parcels uses MPI for parallelising advection, we may need to alter our method of distributing filtering over time/vertical levels.