### PR TITLE
Move dependencies to setup.py

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,4 +7,5 @@ formats: all
 python:
   version: 3.7
   install:
-    - requirements: requirements.txt
+    - method: pip
+      path: .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 cache: pip
 install:
-  - pip install -r requirements.txt
   - pip install -e '.[build]'
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -41,18 +41,14 @@ Python environment.
 1. Clone this repository `git clone https://github.com/angus-g/lagrangian-filtering`
 2. Change to the directory `cd lagrangian-filtering`
 3. (Optional) Create the virtualenv `virtualenv env` and activate it `source env/bin/activate`
-4. Install the prerequisites `pip install -r requirements.txt`
-5. Install the development version of the package `pip install -e .`
+4. Install the development version of the package `pip install -e .`
 
 #### Upgrading
 With the package installed in development mode, updating is as easy as
 `git pull` (or making local changes) in the `lagrangian-filtering`
-directory. If changes are made to the underlying OceanParcels package,
-re-install the prerequisites with `pip install -r
-requirements.txt`. You should see a message about running `git` in the
-output. Failing that, you may manually change to the `src/parcels`
-directory within your pip directory, or your virtualenv, and run `git
-pull` as usual.
+directory. If dependencies (particularly parcels) need to be updated,
+run `pip install --upgrade --upgrade-strategy eager .` to force installation
+of the new versions.
 
 ## Usage
 For the moment, it's easiest to set up the filtering workflow in a script or

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,11 +55,10 @@ version of the package in a virtual environment.
    $ cd lagrangian-filtering
    $ virtualenv env
    $ source env/bin/activate
-   $ pip install -r requirements.txt
    $ pip install -e .
 
-This will install both `lagrangian-filtering` and `parcels` as
-development packages, where changes to the files in the git repository
+This will install `lagrangian-filtering` as a
+development package, where changes to the files in the git repository
 will be reflected in your Python environment. To update `lagrangian-filtering`, run
 
 .. code-block:: console
@@ -71,7 +70,7 @@ In the directory into which you cloned the repository. If the
 
 .. code-block:: console
 
-   $ pip install -r requirements.txt
+   $ pip install --upgrade --upgrade-strategy eager .
 
 will pull changes to its corresponding git repository.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-dask[array]
-h5py
-numpy>=1.17.0
-scipy>=1.2.0
--e git+https://github.com/angus-g/parcels@lagrangian-filtering#egg=parcels

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,14 @@ setup(
     setup_requires=["setuptools_scm"],
     packages=find_packages(),
     extras_require={"build": ["pytest", "xarray", "cloudpickle"]},
+    install_requires=[
+        "dask[array]",
+        "h5py",
+        "numpy>=1.17.0",
+        "scipy>=1.2.0",
+        "xarray",
+        "netCDF4",
+        "cftime",
+        "parcels @ git+https://github.com/angus-g/parcels@lagrangian-filtering",
+    ],
 )


### PR DESCRIPTION
This removes the `requirements.txt` file as a specification of dependencies, which seems more like the correct way of doing things. This is a prerequisite to #54 because parcels itself doesn't specify dependencies outside of conda.