### PR TITLE
Support overriding tracer interpolation with C-grids

### DIFF
--- a/filtering/filter.py
+++ b/filtering/filter.py
@@ -78,7 +78,9 @@ class Filter(object):
             xn[:, :time_index] & is_valid, vl[:, None], x[:, :time_index]
         )
         x[:, time_index + 1 :] = np.where(
-            xn[:, time_index + 1 :] & is_valid, vr[:, None], x[:, time_index + 1 :],
+            xn[:, time_index + 1 :] & is_valid,
+            vr[:, None],
+            x[:, time_index + 1 :],
         )
 
     def apply_filter(self, data, time_index, min_window=None):

--- a/filtering/filtering.py
+++ b/filtering/filtering.py
@@ -150,8 +150,11 @@ class LagrangeFilter(object):
         fieldset_kwargs = kwargs
         fieldset_kwargs.setdefault("mesh", "flat")
         if c_grid:
-            interp_method = {}
+            interp_method = kwargs.get("interp_method", {})
             for v in variables:
+                if v in interp_method:
+                    continue
+
                 if v in ["U", "V", "W"]:
                     interp_method[v] = "cgrid_velocity"
                 else:
@@ -161,7 +164,10 @@ class LagrangeFilter(object):
 
         # construct the OceanParcels FieldSet to use for particle advection
         self.fieldset = fieldset_constructor(
-            filenames_or_dataset, variables, dimensions, **fieldset_kwargs,
+            filenames_or_dataset,
+            variables,
+            dimensions,
+            **fieldset_kwargs,
         )
 
         self._output_field = self.fieldset.get_fields()[0].name

--- a/test/test_lagrangefilter.py
+++ b/test/test_lagrangefilter.py
@@ -69,6 +69,36 @@ def parcels_args(dimensions_grid):
     return arg_tuple + (c_grid,)
 
 
+def test_interp_method(parcels_args, nocompile_LagrangeFilter):
+    """Test that we can set interpolation methods on non-velocity data."""
+
+    dataset, variables, dimensions, c_grid = parcels_args
+
+    interp_method = {"T": "linear_invdist_land_tracer"}
+    if not c_grid:
+        interp_method["U"] = "linear"
+        interp_method["V"] = "linear"
+
+    f = nocompile_LagrangeFilter(
+        "test",
+        dataset,
+        variables,
+        dimensions,
+        sample_variables=["T"],
+        c_grid=c_grid,
+        interp_method=interp_method,
+    )
+
+    # make sure we set the correct interpolation method on the tracer
+    assert f.fieldset.T.interp_method == "linear_invdist_land_tracer"
+
+    # but the velocity should have been automatic
+    if c_grid:
+        assert f.fieldset.U.interp_method == "cgrid_velocity"
+    else:
+        assert f.fieldset.U.interp_method == "linear"
+
+
 def test_particleset_default_particle_locations(parcels_args, nocompile_LagrangeFilter):
     """Test that particles end up at the U-grid gridpoints by default"""
 


### PR DESCRIPTION
On non-C grids, an interp_method dictionary would be passed directly through to the FieldSet constructor without any interference. However, we manually set velocity interp_methods on C-grids to make Parcels happy. The way this was implemented, we would override any existing interp_methods dictionary.

This change overrides velocity components only when they're not already in the dictionary for a C-grid. This could get you into some trouble from Parcels, which likes to enforce specific interpolation methods.