### PR TITLE
Add analysis module with power spectrum method

### DIFF
--- a/docs/exploring.rst
+++ b/docs/exploring.rst
@@ -23,3 +23,19 @@ compute a spectrum for determining an ideal cutoff frequency:
    f = LagrangeFilter(...)
    data = f.advection_step(time)
    mean_u = np.mean(data["var_U"][1], axis=1)
+
+
+Using analysis functions
+========================
+
+As an alternative to using ad-hoc explorations as above, there are
+predefined functions available to give more robust and efficient ways
+to interrogate your data. For example, a mean kinetic energy spectrum
+over all particles could be computed at a specified time:
+
+.. code-block:: python
+
+   from filtering import analysis
+   f = LagrangeFilter(..., sample_variables["U", "V"], ...)
+   spectra = analysis.power_spectrum(f, time)
+   ke_spectrum = spectra["var_U"] + spectra["var_V"]

--- a/filtering/__init__.py
+++ b/filtering/__init__.py
@@ -6,4 +6,5 @@ except DistributionNotFound:
     pass
 
 from filtering.filtering import LagrangeFilter
+import filtering.analysis
 import filtering.filter

--- a/filtering/analysis.py
+++ b/filtering/analysis.py
@@ -1,0 +1,37 @@
+"""Analysis routines for Lagrangian particle data.
+
+These routines take an already-configured 'LagrangeFilter' and produce
+diagnostic output.
+
+"""
+
+import dask.array as da
+
+
+def power_spectrum(filter, time):
+    """Compute the mean power spectrum over all particles at a given time.
+
+    This routine gives the power spectrum (power spectral density) for
+    each of the sampled variables within ''filter'', as a mean over
+    all particles. It will run a single advection step at the specified time.
+
+    Args:
+        filter (filtering.LagrangeFilter): The pre-configured filter object
+            to use for running the analysis.
+        time (float): The time at which to perform the analysis.
+
+    Returns:
+        Dict[str, numpy.array]: A dictionary of power spectra for each of
+            the sampled variables on the filter.
+
+    """
+
+    psds = {}
+    advection_data = filter.advection_step(time, output_time=False)
+
+    for v, a in advection_data.items():
+        spectra = da.fft.fft(a[1].rechunk((-1, "auto")), axis=0)
+        mean_spectrum = da.mean(da.absolute(spectra) ** 2, axis=1)
+        psds[v] = mean_spectrum.compute()
+
+    return psds

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1,0 +1,26 @@
+import pytest
+
+import numpy as np
+
+import filtering
+
+
+def test_power_spectrum(leewave_data):
+    """Test computation of the power spectrum for velocity in
+    the leewave dataset."""
+
+    f = filtering.LagrangeFilter(
+        "power_spectrum",
+        leewave_data,
+        {"U": "U", "V": "V"},
+        {"lon": "x", "lat": "y", "time": "t"},
+        ["U"],
+        window_size=3 * 24 * 3600,
+    )
+    f.make_zonally_periodic()
+    f.make_meridionally_periodic()
+
+    spectrum = filtering.analysis.power_spectrum(f, 7 * 24 * 3600)
+
+    assert "var_U" in spectrum
+    assert np.all(np.isreal(spectrum["var_U"]))


### PR DESCRIPTION
This module should house different analyses for exploring a given dataset before running the actual filtering in anger, e.g. to determine an appropriate cut-off frequency.

Closes #26.