### PR TITLE
Add a spatially-variable filter

### DIFF
--- a/filtering/filter.py
+++ b/filtering/filter.py
@@ -9,6 +9,7 @@ latitude or even arbitrary conditions like vorticity.
 import dask.array as da
 import numpy as np
 from scipy import fftpack, signal
+import sosfilt
 
 
 class Filter(object):
@@ -154,3 +155,68 @@ class FrequencySpaceFilter(Filter):
         # forward transform
         filtered = fftpack.rfft(data, axis=0) * freq_filter[:, None]
         return fftpack.irfft(filtered, axis=0)[time_index, ...]
+
+
+class SpatialFilter(Filter):
+    """A filter with a programmable, variable frequency.
+
+    Example:
+        A Coriolis parameter-dependent filter:
+
+        .. code-block:: python
+
+            Ω = 7.2921e-5
+            f = 2*Ω*np.sin(np.deg2rad(ff.seed_lat))
+            filt = SpatialFilter(f, 1.0 / ff.output_dt)
+
+    Args:
+        frequencies (numpy.ndarray): An array with the same number
+            of elements as seeded particles, containing the cutoff
+            frequency to be used for each particle.
+            cutoff frequency at that location.
+        fs (float): The sampling frequency of the data over which the
+            filter is applied.
+
+    """
+
+    def __init__(self, frequencies, fs):
+        self._filter = SpatialFilter.create_filter(frequencies, fs)
+
+    @staticmethod
+    def create_filter(frequencies, fs):
+        """Create a series of filters.
+
+        This creates an analogue Butterworth filter with the given
+        array of frequencies and sampling parameters.
+
+        Args:
+            frequencies (numpy.ndarray): The high-pass angular cutoff frequencies of the filters.
+            fs (float): The sampling frequency of the data.
+
+        """
+
+        return sosfilt.butter(4, frequencies, "highpass", fs=fs, output="sos")
+
+    def apply_filter(self, data, time_index, min_window=None):
+        """Apply the filter to an array of data."""
+
+        def filter_select(filt, x):
+            if min_window is not None:
+                Filter.pad_window(x, time_index, min_window)
+
+            return sosfilt.sosfiltfilt(filt, x)[..., time_index]
+
+        # we have to make sure the chunking of filter matches that of data
+        data = data.rechunk((-1, "auto"))
+        filt = da.from_array(self._filter, chunks=(data.chunksize[1], None, None))
+
+        filtered = da.apply_gufunc(
+            filter_select,
+            "(s,n),(i)->()",
+            filt,
+            data,
+            axes=[(1, 2), (0,), ()],
+            output_dtypes=data.dtype,
+        )
+
+        return filtered.compute()

--- a/filtering/filtering.py
+++ b/filtering/filtering.py
@@ -185,6 +185,7 @@ class LagrangeFilter(object):
 
         # guess the output timestep from the seed grid
         self.output_dt = self._output_grid.time[1] - self._output_grid.time[0]
+        # default filter frequency
         self.filter_frequency = highpass_frequency / (2 * np.pi)
         self.inertial_filter = None
 
@@ -220,6 +221,36 @@ class LagrangeFilter(object):
         self._min_window = None
         if minimum_window is not None:
             self._min_window = minimum_window / self.output_dt
+
+    @property
+    def seed_lat(self):
+        """The 2D grid of seed particle latitudes.
+
+        Note:
+            This is determined by :func:`~set_particle_grid` and
+            :func:`~seed_subdomain`.
+
+        Returns:
+            numpy.ndarray: The seed particle latitudes.
+
+        """
+
+        return self._grid_lat
+
+    @property
+    def seed_lon(self):
+        """The 2D grid of seed particle longitudes.
+
+        Note:
+            This is determined by :func:`~set_particle_grid` and
+            :func:`~seed_subdomain`.
+
+        Returns:
+            numpy.ndarray: The seed particle longitudes.
+
+        """
+
+        return self._grid_lon
 
     def _set_grid(self, grid):
         """Set the seeding grid from a parcels grid"""

--- a/meta.yaml
+++ b/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - scipy >=1.2.0
     - parcels >=2.1.5
     - pykdtree
+    - sosfilt
 
 about:
   home: https://github.com/angus-g/lagrangian-filtering

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(
         "netCDF4",
         "parcels @ git+https://github.com/angus-g/parcels.git@openmp-loop#egg=parcels",
         "pykdtree",
+        "sosfilt",
     ],
 )

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -30,3 +30,19 @@ def test_frequency_filter(leewave_data):
     U_filt = f.filter_step(adv)["var_U"].reshape(leewave_data.y.size, -1)
 
     assert np.all((leewave_data.U_orig.data - U_filt[0, :]) ** 2 < 3e-8)
+
+
+def test_spatial_filter():
+    """Test creation and frequency response of a latitude-dependent filter."""
+
+    lons = np.array([0])
+    lats = np.array([1, 2])
+
+    lons, lats = np.meshgrid(lons, lats)
+
+    f = lats * 0.1
+    filt = filtering.filter.SpatialFilter(f, 1)
+
+    for freq, filter_obj in zip(f, filt._filter):
+        w, h = signal.sosfreqz(filter_obj)
+        assert np.all(abs(h)[w < freq] < 0.1)


### PR DESCRIPTION
This is a filter which can be initialised in a couple of ways:

- [x] with a lat/lon grid corresponding to the particle seed locations (the cutoff frequency is calculated dynamically)
- [x] with a predetermined array/grid of cutoff frequencies
- [ ] documentation for building the filter and attaching it to a `LagrangeFilter`

Using the https://github.com/angus-g/sosfilt library, we can then efficiently apply these multiple filters in parallel. There are a few other things that might be good to tackle here:

- [ ] extend the same concept to the `FrequencySpaceFilter`, which should be much simpler because it's just a mask of an FFT
- [ ] refactor some of the OO design so we're not repeating calls to `Filter.pad_window`

Closes #5.